### PR TITLE
Feature/syntax parity with other api clients

### DIFF
--- a/Duffel.ApiClient/Duffel.ApiClient.csproj
+++ b/Duffel.ApiClient/Duffel.ApiClient.csproj
@@ -6,14 +6,14 @@
         <Authors>Duffel Technology Ltd.</Authors>
         <Copyright>Duffel Technology Ltd.</Copyright>
         <Company>Duffel Technology Ltd.</Company>
-        <PackageVersion>0.1.0</PackageVersion>
+        <PackageVersion>0.2.0</PackageVersion>
         <Title>dotNet client for interacting with the Duffel API</Title>
         <PackageProjectUrl>https://duffel.com/docs/api/overview/welcome</PackageProjectUrl>
         <RepositoryUrl>https://github.com/duffelhq/duffel-api-dotnet</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <FileVersion>0.1.0</FileVersion>
-        <PackageLicenseUrl>https://raw.githubusercontent.com/duffelhq/duffel-api-dotnet/main/LICENSE</PackageLicenseUrl>
+        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <FileVersion>0.2.0</FileVersion>
+        <PackageLicenseUrl></PackageLicenseUrl>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Duffel.ApiClient/DuffelApiClient.cs
+++ b/Duffel.ApiClient/DuffelApiClient.cs
@@ -20,7 +20,8 @@ namespace Duffel.ApiClient
         public OrderChangeRequests OrderChangeRequests { get; set; }
         public OrderChanges OrderChanges { get; set; }
         public OrderChangeOffers OrderChangeOffers { get; set; }
-
+        public OrderCancellations OrderCancellations { get; set; }
+        
         public DuffelApiClient(string accessToken, bool production = false)
         {
             _httpClient = new HttpClient();
@@ -58,6 +59,7 @@ namespace Duffel.ApiClient
             OrderChangeRequests = new OrderChangeRequests(_httpClient);
             OrderChanges = new OrderChanges(_httpClient);
             OrderChangeOffers = new OrderChangeOffers(_httpClient);
+            OrderCancellations = new OrderCancellations(_httpClient);
         }
     }
 }

--- a/Duffel.ApiClient/DuffelResponsePage.cs
+++ b/Duffel.ApiClient/DuffelResponsePage.cs
@@ -7,15 +7,15 @@ namespace Duffel.ApiClient
     /// <typeparam name="T">Type of data in the response</typeparam>
     public class DuffelResponsePage<T> where T: class
     {
-        public DuffelResponsePage(T data, string previousPage, string nextPage, int limit = 50)
+        public DuffelResponsePage(T data, string before, string after, int limit = 50)
         {
-            PreviousPage = !string.IsNullOrEmpty(previousPage) ? $"before={previousPage}" : "";
-            NextPage = !string.IsNullOrEmpty(nextPage) ? $"after={nextPage}" : "";
+            Before = !string.IsNullOrEmpty(before) ? $"before={before}" : "";
+            After = !string.IsNullOrEmpty(after) ? $"after={after}" : "";
             Limit = limit;
             Data = data;
         }
-        public string PreviousPage { get; }
-        public string NextPage { get; }
+        public string Before { get; }
+        public string After { get; }
         public int Limit { get; }
         public T Data { get; }
         

--- a/Duffel.ApiClient/IDuffelApiClient.cs
+++ b/Duffel.ApiClient/IDuffelApiClient.cs
@@ -15,6 +15,7 @@ namespace Duffel.ApiClient
          OrderChangeRequests OrderChangeRequests { get; }
          OrderChanges OrderChanges { get; }
          OrderChangeOffers OrderChangeOffers { get; }
+         OrderCancellations OrderCancellations { get; }
         
     }
 }

--- a/Duffel.ApiClient/Resources/OfferRequests.cs
+++ b/Duffel.ApiClient/Resources/OfferRequests.cs
@@ -53,9 +53,9 @@ namespace Duffel.ApiClient.Resources
             List<OffersResponse> result = new List<OffersResponse>();
             var page = await Get(limit: 200);
             result.AddRange(page.Data);
-            while (!string.IsNullOrEmpty(page.NextPage))
+            while (!string.IsNullOrEmpty(page.After))
             {
-                page = await Get(limit: 200, after: page.NextPage, before: page.PreviousPage);
+                page = await Get(limit: 200, after: page.After, before: page.Before);
                 result.AddRange(page.Data);
             }
 

--- a/Duffel.ApiClient/Resources/OfferRequests.cs
+++ b/Duffel.ApiClient/Resources/OfferRequests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -45,7 +44,10 @@ namespace Duffel.ApiClient.Resources
 
         public async Task<DuffelResponsePage<IEnumerable<OffersResponse>>> List(string before = "", string after = "", int limit = 50)
         {
-            return await RetrievePaginatedContent($"air/offer_requests?limit={limit}&{after}");
+            var withBefore = string.IsNullOrEmpty(before) ? "" : $"&{before}";
+            var withAfter = string.IsNullOrEmpty(after) ? "" : $"&{after}";
+            
+            return await RetrievePaginatedContent($"air/offer_requests?limit={limit}{withBefore}{withAfter}");
         }
 
         public async Task<IEnumerable<OffersResponse>> GetAll()

--- a/Duffel.ApiClient/Resources/OfferRequests.cs
+++ b/Duffel.ApiClient/Resources/OfferRequests.cs
@@ -43,7 +43,7 @@ namespace Duffel.ApiClient.Resources
             return await SingleItemResponseConverter.GetAndDeserialize<OffersResponse>(result);
         }
 
-        public async Task<DuffelResponsePage<IEnumerable<OffersResponse>>> Get(string before = "", string after = "", int limit = 50)
+        public async Task<DuffelResponsePage<IEnumerable<OffersResponse>>> List(string before = "", string after = "", int limit = 50)
         {
             return await RetrievePaginatedContent($"air/offer_requests?limit={limit}&{after}");
         }
@@ -51,11 +51,11 @@ namespace Duffel.ApiClient.Resources
         public async Task<IEnumerable<OffersResponse>> GetAll()
         {
             List<OffersResponse> result = new List<OffersResponse>();
-            var page = await Get(limit: 200);
+            var page = await List(limit: 200);
             result.AddRange(page.Data);
             while (!string.IsNullOrEmpty(page.After))
             {
-                page = await Get(limit: 200, after: page.After, before: page.Before);
+                page = await List(limit: 200, after: page.After, before: page.Before);
                 result.AddRange(page.Data);
             }
 

--- a/Duffel.ApiClient/Resources/Offers.cs
+++ b/Duffel.ApiClient/Resources/Offers.cs
@@ -23,7 +23,7 @@ namespace Duffel.ApiClient.Resources
             return await SingleItemResponseConverter.GetAndDeserialize<Offer>(result);
         }
 
-        public async Task<DuffelResponsePage<IEnumerable<Offer>>> Get(string offerRequestId, string before = "",
+        public async Task<DuffelResponsePage<IEnumerable<Offer>>> List(string offerRequestId, string before = "",
             string after = "", int limit = 50, int maxConnections = 2,
             string sortOrder = "total_amount")
         {

--- a/Duffel.ApiClient/Resources/OrderCancellations.cs
+++ b/Duffel.ApiClient/Resources/OrderCancellations.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Duffel.ApiClient.Converters;
+using Duffel.ApiClient.Models.Requests;
+using Duffel.ApiClient.Models.Responses;
+
+namespace Duffel.ApiClient.Resources
+{
+    public class OrderCancellations : BaseResource<OrderCancellation>
+    {
+        public OrderCancellations(HttpClient httpClient) : base(httpClient)
+        {
+        }
+        
+        /// <summary>
+        /// To cancel an order, you'll need to create an order cancellation, check the refund_amount returned, and, if you're happy to go ahead and cancel the order.
+        /// The refund specified by refund_amount, if any, will be returned to your original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
+        /// </summary>
+        public async Task<OrderCancellation> Create(string orderId)
+        {
+            var payload = OrderCancellationConverter.Serialize(new OrderCancellationRequest
+            {
+                OrderId = orderId
+            });
+            
+            var result = await HttpClient.PostAsync($"air/order_cancellations",
+                new StringContent(payload, Encoding.UTF8, "application/json"));
+            
+            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
+        }
+        
+        /// <summary>
+        /// Once you've created a pending order cancellation, you'll know the refund_amount you're due to get back.
+        /// To actually cancel the order, you'll need to confirm the cancellation. The booking with the airline will be cancelled, and the refund_amount will be returned to the original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
+        /// </summary>
+        public async Task<OrderCancellation> Confirm(string cancellationRequestId)
+        {
+            var result = await HttpClient.PostAsync($"air/order_cancellations/{cancellationRequestId}/actions/confirm",
+                new StringContent("", Encoding.UTF8, "application/json"));
+            
+            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
+        }
+        
+        /// <summary>
+        /// Retrieves an order cancellation by its ID.
+        /// </summary>
+        public async Task<OrderCancellation> Get(string cancellationRequestId)
+        {
+            var result = await HttpClient.GetAsync($"air/order_cancellations/{cancellationRequestId}");
+            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
+        }
+        
+        public async Task<DuffelResponsePage<IEnumerable<OrderCancellation>>> List(string before = "", string after = "", int limit = 50, string order_id = "")
+        {
+            var url = $"air/order_cancellations?limit={limit}";
+
+            if (!string.IsNullOrEmpty(before)) url += $"&{before}";
+            if (!string.IsNullOrEmpty(after)) url += $"&{after}";
+            if (!string.IsNullOrEmpty(order_id)) url += $"&order_id={order_id}";
+            
+            var result = await HttpClient.GetAsync(url);
+            var content = await result.Content.ReadAsStringAsync();
+            return PagedResponseConverter.Deserialize<OrderCancellation>(content, result.StatusCode);
+        }
+    }
+}

--- a/Duffel.ApiClient/Resources/OrderChanges.cs
+++ b/Duffel.ApiClient/Resources/OrderChanges.cs
@@ -20,15 +20,15 @@ namespace Duffel.ApiClient.Resources
             _httpClient = httpClient;
         }
 
-        public async Task<OrderChange> CreatePending(string orderChangeRequestId, string selectedOfferId)
+        public async Task<OrderChange> Create(string orderChangeOfferId)
         {
             var settings = new JsonSerializerSettings();
             settings.Converters.Add(new StringEnumConverter {NamingStrategy = new SnakeCaseNamingStrategy()});
             var payload =  JsonConvert.SerializeObject(
                 new DuffelDataWrapper<SelectedOrderChangeOffer>(
-                    new SelectedOrderChangeOffer { Id = selectedOfferId }), Formatting.None, settings);
+                    new SelectedOrderChangeOffer { Id = orderChangeOfferId }), Formatting.None, settings);
 
-            var result = await _httpClient.PostAsync($"air/order_changes/{orderChangeRequestId}",
+            var result = await _httpClient.PostAsync($"air/order_changes/{orderChangeOfferId}",
                 new StringContent(payload, Encoding.UTF8, "application/json"));
 
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChange>(result);

--- a/Duffel.ApiClient/Resources/OrderChanges.cs
+++ b/Duffel.ApiClient/Resources/OrderChanges.cs
@@ -40,7 +40,7 @@ namespace Duffel.ApiClient.Resources
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChange>(result);
         }
         
-        public async Task<OrderChange> ConfirmPending(string orderChangeId, Payment payment)
+        public async Task<OrderChange> Confirm(string orderChangeId, Payment payment)
         {
             var settings = new JsonSerializerSettings();
             settings.Converters.Add(new StringEnumConverter {NamingStrategy = new SnakeCaseNamingStrategy()});

--- a/Duffel.ApiClient/Resources/Orders.cs
+++ b/Duffel.ApiClient/Resources/Orders.cs
@@ -45,58 +45,6 @@ namespace Duffel.ApiClient.Resources
                 new StringContent(payload, Encoding.UTF8, "application/json"));
             
             return await SingleItemResponseConverter.GetAndDeserialize<Order>(result);
-            
-        }
-
-        /// <summary>
-        /// To cancel an order, you'll need to create an order cancellation, check the refund_amount returned, and, if you're happy to go ahead and cancel the order.
-        /// The refund specified by refund_amount, if any, will be returned to your original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
-        /// </summary>
-        public async Task<OrderCancellation> CreateOrderCancellation(string orderId)
-        {
-            var payload = OrderCancellationConverter.Serialize(new OrderCancellationRequest
-            {
-                OrderId = orderId
-            });
-            
-            var result = await HttpClient.PostAsync($"air/order_cancellations",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
-            
-            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
-        }
-
-        /// <summary>
-        /// Once you've created a pending order cancellation, you'll know the refund_amount you're due to get back.
-        /// To actually cancel the order, you'll need to confirm the cancellation. The booking with the airline will be cancelled, and the refund_amount will be returned to the original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
-        /// </summary>
-        public async Task<OrderCancellation> ConfirmOrderCancellation(string cancellationRequestId)
-        {
-            var result = await HttpClient.PostAsync($"air/order_cancellations/{cancellationRequestId}/actions/confirm",
-                new StringContent("", Encoding.UTF8, "application/json"));
-            
-            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
-        }
-
-        /// <summary>
-        /// Retrieves an order cancellation by its ID.
-        /// </summary>
-        public async Task<OrderCancellation> GetOrderCancellation(string cancellationRequestId)
-        {
-            var result = await HttpClient.GetAsync($"air/order_cancellations/{cancellationRequestId}");
-            return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
-        }
-
-        public async Task<DuffelResponsePage<IEnumerable<OrderCancellation>>> GetOrderCancellations(string before = "", string after = "", int limit = 50, string order_id = "")
-        {
-            var url = $"air/order_cancellations?limit={limit}";
-
-            if (!string.IsNullOrEmpty(before)) url += $"&{before}";
-            if (!string.IsNullOrEmpty(after)) url += $"&{after}";
-            if (!string.IsNullOrEmpty(order_id)) url += $"&order_id={order_id}";
-            
-            var result = await HttpClient.GetAsync(url);
-            var content = await result.Content.ReadAsStringAsync();
-            return PagedResponseConverter.Deserialize<OrderCancellation>(content, result.StatusCode);
         }
     }
 }

--- a/Duffel.ApiClient/Resources/Resource.cs
+++ b/Duffel.ApiClient/Resources/Resource.cs
@@ -30,9 +30,9 @@ namespace Duffel.ApiClient.Resources
             List<T> result = new List<T>();
             var page = await Get(limit: 200);
             result.AddRange(page.Data);
-            while (!string.IsNullOrEmpty(page.NextPage))
+            while (!string.IsNullOrEmpty(page.After))
             {
-                page = await Get(limit: page.Limit, after: page.NextPage, before: page.PreviousPage);
+                page = await Get(limit: page.Limit, after: page.After, before: page.Before);
                 result.AddRange(page.Data);
             }
 

--- a/Duffel.ApiClient/Resources/Resource.cs
+++ b/Duffel.ApiClient/Resources/Resource.cs
@@ -22,7 +22,9 @@ namespace Duffel.ApiClient.Resources
         
         public async Task<DuffelResponsePage<IEnumerable<T>>> List(int limit = 50, string before = "", string after = "")
         {
-            return await RetrievePaginatedContent($"air/{ResourceName}?limit={limit}&{after}");
+            var withBefore = string.IsNullOrEmpty(before) ? "" : $"&{before}";
+            var withAfter = string.IsNullOrEmpty(after) ? "" : $"&{after}";
+            return await RetrievePaginatedContent($"air/{ResourceName}?limit={limit}{withBefore}{withAfter}");
         }
 
         public async Task<IEnumerable<T>> GetAll()

--- a/Duffel.ApiClient/Resources/Resource.cs
+++ b/Duffel.ApiClient/Resources/Resource.cs
@@ -20,7 +20,7 @@ namespace Duffel.ApiClient.Resources
             return await SingleItemResponseConverter.GetAndDeserialize<T>(result);
         }
         
-        public async Task<DuffelResponsePage<IEnumerable<T>>> Get(int limit = 50, string before = "", string after = "")
+        public async Task<DuffelResponsePage<IEnumerable<T>>> List(int limit = 50, string before = "", string after = "")
         {
             return await RetrievePaginatedContent($"air/{ResourceName}?limit={limit}&{after}");
         }
@@ -28,11 +28,11 @@ namespace Duffel.ApiClient.Resources
         public async Task<IEnumerable<T>> GetAll()
         {
             List<T> result = new List<T>();
-            var page = await Get(limit: 200);
+            var page = await List(limit: 200);
             result.AddRange(page.Data);
             while (!string.IsNullOrEmpty(page.After))
             {
-                page = await Get(limit: page.Limit, after: page.After, before: page.Before);
+                page = await List(limit: page.Limit, after: page.After, before: page.Before);
                 result.AddRange(page.Data);
             }
 

--- a/examples/BookAndChange/Program.cs
+++ b/examples/BookAndChange/Program.cs
@@ -105,7 +105,7 @@ try
     var orderChangeOffers = await client.OrderChangeOffers.List(orderChangeRequest.Id);
     Console.WriteLine("Picking first option for changing the order.");
 
-    var orderChange = await client.OrderChanges.CreatePending(orderChangeRequest.Id, orderChangeOffers.Data.First().Id);
+    var orderChange = await client.OrderChanges.Create(orderChangeOffers.Data.First().Id);
     Console.WriteLine($"Created order change with ID: {orderChange.Id}, confirming...");
 
     var confirmedOrderChange = await client.OrderChanges.ConfirmPending(orderChange.Id, new Balance

--- a/examples/BookAndChange/Program.cs
+++ b/examples/BookAndChange/Program.cs
@@ -108,7 +108,7 @@ try
     var orderChange = await client.OrderChanges.Create(orderChangeOffers.Data.First().Id);
     Console.WriteLine($"Created order change with ID: {orderChange.Id}, confirming...");
 
-    var confirmedOrderChange = await client.OrderChanges.ConfirmPending(orderChange.Id, new Balance
+    var confirmedOrderChange = await client.OrderChanges.Confirm(orderChange.Id, new Balance
     {
         Amount = orderChange.ChangeTotalAmount,
         Currency = orderChange.ChangeTotalCurrency

--- a/examples/SearchAndBook/Program.cs
+++ b/examples/SearchAndBook/Program.cs
@@ -81,9 +81,9 @@ var orderRequest = new OrderRequest
 var order = await client.Orders.Create(orderRequest);
 Console.WriteLine($"Created order {order.Id} with booking reference {order.BookingReference}");
 
-var orderCancellation = await client.Orders.CreateOrderCancellation(order.Id);
+var orderCancellation = await client.OrderCancellations.Create(order.Id);
 Console.WriteLine($"Requested refund quote for order {order.Id}, cancellation request id: {orderCancellation.Id}");
 Console.WriteLine($" {orderCancellation.RefundCurrency} {orderCancellation.RefundAmount} available");
 
-var confirmation = await client.Orders.ConfirmOrderCancellation(orderCancellation.Id);
+var confirmation = await client.OrderCancellations.Confirm(orderCancellation.Id);
 Console.WriteLine($"Confirmed refund quote for order {order.Id}");


### PR DESCRIPTION
- Use OrderCancellations resource
- Use List() method for getting multiple entities
- Rename paging tokens to be `before` and `after`
- Make sure both paging tokens are used in all List() methods