### PR TITLE
Add call to ConfigureAwait(false) on first async

### DIFF
--- a/Duffel.ApiClient/Converters/SingleItemResponseConverter.cs
+++ b/Duffel.ApiClient/Converters/SingleItemResponseConverter.cs
@@ -12,7 +12,7 @@ namespace Duffel.ApiClient.Converters
     {
         public static async Task<T> GetAndDeserialize<T>(HttpResponseMessage response) where T : class
         {
-            var payload = await response.Content.ReadAsStringAsync();
+            var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return Deserialize<T>(payload, response.StatusCode);
         }
 

--- a/Duffel.ApiClient/Resources/BaseResource.cs
+++ b/Duffel.ApiClient/Resources/BaseResource.cs
@@ -22,7 +22,8 @@ namespace Duffel.ApiClient.Resources
         
         protected async Task<DuffelResponsePage<IEnumerable<T>>> RetrievePaginatedContent(string url)
         {
-            var result = await _httpClient.GetAsync(url);
+            var result = await _httpClient.GetAsync(url)
+                .ConfigureAwait(false);
             var content = await result.Content.ReadAsStringAsync();
             return PagedResponseConverter.Deserialize<T>(content, result.StatusCode);
         }

--- a/Duffel.ApiClient/Resources/OfferRequests.cs
+++ b/Duffel.ApiClient/Resources/OfferRequests.cs
@@ -30,15 +30,15 @@ namespace Duffel.ApiClient.Resources
         public async Task<OffersResponse> Create(OffersRequest request, bool returnOffers = true)
         {
             var payload = OffersResponseConverter.Serialize(request);
-            var result = await HttpClient.PostAsync($"air/offer_requests", 
-                new StringContent(payload,  Encoding.UTF8, "application/json"));
+            var result = await HttpClient.PostAsync($"air/offer_requests",
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
 
             return await SingleItemResponseConverter.GetAndDeserialize<OffersResponse>(result);
         }
 
         public async Task<OffersResponse> Get(string offerRequestId)
         {
-            var result = await HttpClient.GetAsync($"air/offer_requests/{offerRequestId}");
+            var result = await HttpClient.GetAsync($"air/offer_requests/{offerRequestId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<OffersResponse>(result);
         }
 

--- a/Duffel.ApiClient/Resources/Offers.cs
+++ b/Duffel.ApiClient/Resources/Offers.cs
@@ -19,7 +19,9 @@ namespace Duffel.ApiClient.Resources
 
         public async Task<Offer> Get(string offerId, bool returnAvailableServices = false)
         {
-            var result = await HttpClient.GetAsync($"air/offers/{offerId}?return_available_services={returnAvailableServices.ToString().ToLower()}");
+            var result = await HttpClient.GetAsync(
+                    $"air/offers/{offerId}?return_available_services={returnAvailableServices.ToString().ToLower()}")
+                .ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<Offer>(result);
         }
 
@@ -39,7 +41,7 @@ namespace Duffel.ApiClient.Resources
         public async Task<Passenger> UpdatePassenger(string offerId, Passenger passengerData)
         {
             var payload = JsonConvert.SerializeObject(new DuffelDataWrapper<Passenger>(passengerData), Formatting.None, new StringEnumConverter());
-            var result = await HttpClient.PatchAsync($"air/offers/{offerId}/passengers/{passengerData.Id}", new StringContent(payload, Encoding.UTF8, "application/json"));
+            var result = await HttpClient.PatchAsync($"air/offers/{offerId}/passengers/{passengerData.Id}", new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             var content = await result.Content.ReadAsStringAsync();
             var response = JsonConvert.DeserializeObject<DuffelResponseWrapper<Passenger>>(content);
             if (response != null && response.Errors != null && response.Errors.Any())

--- a/Duffel.ApiClient/Resources/OrderCancellations.cs
+++ b/Duffel.ApiClient/Resources/OrderCancellations.cs
@@ -26,7 +26,7 @@ namespace Duffel.ApiClient.Resources
             });
             
             var result = await HttpClient.PostAsync($"air/order_cancellations",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             
             return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
         }
@@ -38,7 +38,7 @@ namespace Duffel.ApiClient.Resources
         public async Task<OrderCancellation> Confirm(string cancellationRequestId)
         {
             var result = await HttpClient.PostAsync($"air/order_cancellations/{cancellationRequestId}/actions/confirm",
-                new StringContent("", Encoding.UTF8, "application/json"));
+                new StringContent("", Encoding.UTF8, "application/json")).ConfigureAwait(false);
             
             return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
         }
@@ -48,7 +48,7 @@ namespace Duffel.ApiClient.Resources
         /// </summary>
         public async Task<OrderCancellation> Get(string cancellationRequestId)
         {
-            var result = await HttpClient.GetAsync($"air/order_cancellations/{cancellationRequestId}");
+            var result = await HttpClient.GetAsync($"air/order_cancellations/{cancellationRequestId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<OrderCancellation>(result);
         }
         
@@ -60,7 +60,7 @@ namespace Duffel.ApiClient.Resources
             if (!string.IsNullOrEmpty(after)) url += $"&{after}";
             if (!string.IsNullOrEmpty(order_id)) url += $"&order_id={order_id}";
             
-            var result = await HttpClient.GetAsync(url);
+            var result = await HttpClient.GetAsync(url).ConfigureAwait(false);
             var content = await result.Content.ReadAsStringAsync();
             return PagedResponseConverter.Deserialize<OrderCancellation>(content, result.StatusCode);
         }

--- a/Duffel.ApiClient/Resources/OrderChangeOffers.cs
+++ b/Duffel.ApiClient/Resources/OrderChangeOffers.cs
@@ -21,7 +21,7 @@ namespace Duffel.ApiClient.Resources
         /// <param name="orderChangeOfferId">Duffel's unique identifier for the order change offer</param>
         public async Task<OrderChangeOffer> Get(string orderChangeOfferId)
         {
-            var result = await _httpClient.GetAsync($"/air/order_change_offers/{orderChangeOfferId}");
+            var result = await _httpClient.GetAsync($"/air/order_change_offers/{orderChangeOfferId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChangeOffer>(result);
         }
         
@@ -40,7 +40,7 @@ namespace Duffel.ApiClient.Resources
 
         private async Task<DuffelResponsePage<IEnumerable<T>>> RetrievePaginatedContent<T>(string url) where T: class
         {
-            var result = await _httpClient.GetAsync(url);
+            var result = await _httpClient.GetAsync(url).ConfigureAwait(false);
             var content = await result.Content.ReadAsStringAsync();
             return PagedResponseConverter.Deserialize<T>(content, result.StatusCode);
         }

--- a/Duffel.ApiClient/Resources/OrderChangeRequests.cs
+++ b/Duffel.ApiClient/Resources/OrderChangeRequests.cs
@@ -21,14 +21,14 @@ namespace Duffel.ApiClient.Resources
             var payload = OrderChangeConverter.Serialize(request);
             
             var result = await _httpClient.PostAsync($"air/order_change_requests",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChangeResponse>(result);
         }
 
         public async Task<OrderChangeResponse> Get(string orderChangeRequestId)
         {
-            var result = await _httpClient.GetAsync($"/air/order_change_requests/{orderChangeRequestId}");
+            var result = await _httpClient.GetAsync($"/air/order_change_requests/{orderChangeRequestId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChangeResponse>(result);
         }
     }

--- a/Duffel.ApiClient/Resources/OrderChanges.cs
+++ b/Duffel.ApiClient/Resources/OrderChanges.cs
@@ -29,14 +29,14 @@ namespace Duffel.ApiClient.Resources
                     new SelectedOrderChangeOffer { Id = orderChangeOfferId }), Formatting.None, settings);
 
             var result = await _httpClient.PostAsync($"air/order_changes/{orderChangeOfferId}",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
 
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChange>(result);
         }
 
         public async Task<OrderChange> Get(string orderChangeId)
         {
-            var result = await _httpClient.GetAsync($"air/order_changes/{orderChangeId}");
+            var result = await _httpClient.GetAsync($"air/order_changes/{orderChangeId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChange>(result);
         }
         
@@ -46,8 +46,8 @@ namespace Duffel.ApiClient.Resources
             settings.Converters.Add(new StringEnumConverter {NamingStrategy = new SnakeCaseNamingStrategy()});
             var content = JsonConvert.SerializeObject(new DuffelDataWrapper<Payment>(payment), Formatting.None, settings);
             
-            var result = await _httpClient.PostAsync($"air/order_changes/{orderChangeId}/actions/confirm", 
-                new StringContent(content,  Encoding.UTF8, "application/json"));
+            var result = await _httpClient.PostAsync($"air/order_changes/{orderChangeId}/actions/confirm",
+                new StringContent(content, Encoding.UTF8, "application/json")).ConfigureAwait(false);
 
             return await SingleItemResponseConverter.GetAndDeserialize<OrderChange>(result);
         }

--- a/Duffel.ApiClient/Resources/Orders.cs
+++ b/Duffel.ApiClient/Resources/Orders.cs
@@ -27,13 +27,13 @@ namespace Duffel.ApiClient.Resources
         {
             var payload = OrderConverter.Serialize(request);
             var result = await HttpClient.PostAsync($"air/orders",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<Order>(result);
         }
 
         public async Task<Order> Get(string orderId)
         {
-            var result = await HttpClient.GetAsync($"air/orders/{orderId}");
+            var result = await HttpClient.GetAsync($"air/orders/{orderId}").ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<Order>(result);
         }
 
@@ -42,7 +42,7 @@ namespace Duffel.ApiClient.Resources
             var payload = OrderConverter.SerializeMetadata(metadata);
             
             var result = await HttpClient.PatchAsync($"air/orders/{orderId}",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             
             return await SingleItemResponseConverter.GetAndDeserialize<Order>(result);
         }

--- a/Duffel.ApiClient/Resources/Payments.cs
+++ b/Duffel.ApiClient/Resources/Payments.cs
@@ -21,7 +21,7 @@ namespace Duffel.ApiClient.Resources
             var payload = PaymentResponseConverter.Serialize(paymentRequest);
             
             var result = await _httpClient.PostAsync($"air/payments",
-                new StringContent(payload, Encoding.UTF8, "application/json"));
+                new StringContent(payload, Encoding.UTF8, "application/json")).ConfigureAwait(false);
             
             return await SingleItemResponseConverter.GetAndDeserialize<PaymentResponse>(result);
         }

--- a/Duffel.ApiClient/Resources/Resource.cs
+++ b/Duffel.ApiClient/Resources/Resource.cs
@@ -16,7 +16,8 @@ namespace Duffel.ApiClient.Resources
 
         public async Task<T> Get(string id) 
         {
-            var result = await HttpClient.GetAsync($"air/{ResourceName}/{id}");
+            var result = await HttpClient.GetAsync($"air/{ResourceName}/{id}")
+                .ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<T>(result);
         }
         

--- a/Duffel.ApiClient/Resources/SeatMaps.cs
+++ b/Duffel.ApiClient/Resources/SeatMaps.cs
@@ -25,7 +25,8 @@ namespace Duffel.ApiClient.Resources
 
         public async Task<IEnumerable<SeatMap>> Get(string offerId)
         {
-            var result = await _httpClient.GetAsync($"air/seat_maps?offer_id={offerId}");
+            var result = await _httpClient.GetAsync($"air/seat_maps?offer_id={offerId}")
+                .ConfigureAwait(false);
             return await SingleItemResponseConverter.GetAndDeserialize<IEnumerable<SeatMap>>(result);
         }
     }


### PR DESCRIPTION
To avoid consumers having deadlock, add ConfigureAwait(false) on the
http client calls.

More info here
https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f
