### PR TITLE
Extract interfaces for all resources

### DIFF
--- a/Duffel.ApiClient/Duffel.ApiClient.csproj
+++ b/Duffel.ApiClient/Duffel.ApiClient.csproj
@@ -6,13 +6,13 @@
         <Authors>Duffel Technology Ltd.</Authors>
         <Copyright>Duffel Technology Ltd.</Copyright>
         <Company>Duffel Technology Ltd.</Company>
-        <PackageVersion>0.3.0</PackageVersion>
+        <PackageVersion>0.4.0</PackageVersion>
         <Title>dotNet client for interacting with the Duffel API</Title>
         <PackageProjectUrl>https://duffel.com/docs/api/overview/welcome</PackageProjectUrl>
         <RepositoryUrl>https://github.com/duffelhq/duffel-api-dotnet</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <AssemblyVersion>0.3.0</AssemblyVersion>
-        <FileVersion>0.3.0</FileVersion>
+        <AssemblyVersion>0.4.0</AssemblyVersion>
+        <FileVersion>0.4.0</FileVersion>
         <PackageLicenseUrl></PackageLicenseUrl>
     </PropertyGroup>
 

--- a/Duffel.ApiClient/DuffelApiClient.cs
+++ b/Duffel.ApiClient/DuffelApiClient.cs
@@ -9,18 +9,18 @@ namespace Duffel.ApiClient
     {
         private readonly HttpClient _httpClient;
         
-        public Airlines Airlines { get; set; }
-        public Airports Airports { get; set; }
-        public Aircraft Aircraft { get; set; }
-        public OfferRequests OfferRequests { get; set; }
-        public Offers Offers { get; set; }
-        public Orders Orders { get; set; }
-        public SeatMaps SeatMaps { get; set; }
-        public Payments Payments { get; set; }
-        public OrderChangeRequests OrderChangeRequests { get; set; }
-        public OrderChanges OrderChanges { get; set; }
-        public OrderChangeOffers OrderChangeOffers { get; set; }
-        public OrderCancellations OrderCancellations { get; set; }
+        public IAirlines Airlines { get; set; }
+        public IAirports Airports { get; set; }
+        public IAircraft Aircraft { get; set; }
+        public IOfferRequests OfferRequests { get; set; }
+        public IOffers Offers { get; set; }
+        public IOrders Orders { get; set; }
+        public ISeatMaps SeatMaps { get; set; }
+        public IPayments Payments { get; set; }
+        public IOrderChangeRequests OrderChangeRequests { get; set; }
+        public IOrderChanges OrderChanges { get; set; }
+        public IOrderChangeOffers OrderChangeOffers { get; set; }
+        public IOrderCancellations OrderCancellations { get; set; }
         
         public DuffelApiClient(string accessToken, bool production = false)
         {

--- a/Duffel.ApiClient/IDuffelApiClient.cs
+++ b/Duffel.ApiClient/IDuffelApiClient.cs
@@ -4,18 +4,17 @@ namespace Duffel.ApiClient
 {
     public interface IDuffelApiClient
     {
-         Aircraft Aircraft { get; }
-         Airlines Airlines { get; }
-         Airports Airports { get; }
-         Offers Offers { get; }
-         OfferRequests OfferRequests { get; }
-         Orders Orders { get; }
-         SeatMaps SeatMaps { get; }
-         Payments Payments { get; }
-         OrderChangeRequests OrderChangeRequests { get; }
-         OrderChanges OrderChanges { get; }
-         OrderChangeOffers OrderChangeOffers { get; }
-         OrderCancellations OrderCancellations { get; }
-        
+         IAircraft Aircraft { get; }
+         IAirlines Airlines { get; }
+         IAirports Airports { get; }
+         IOffers Offers { get; }
+         IOfferRequests OfferRequests { get; }
+         IOrders Orders { get; }
+         ISeatMaps SeatMaps { get; }
+         IPayments Payments { get; }
+         IOrderChangeRequests OrderChangeRequests { get; }
+         IOrderChanges OrderChanges { get; }
+         IOrderChangeOffers OrderChangeOffers { get; }
+         IOrderCancellations OrderCancellations { get; }
     }
 }

--- a/Duffel.ApiClient/Resources/Aircraft.cs
+++ b/Duffel.ApiClient/Resources/Aircraft.cs
@@ -1,9 +1,18 @@
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Duffel.ApiClient.Models;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Aircraft : Resource<Models.Aircraft>
+    public interface IAircraft
+    {
+        Task<Models.Aircraft> Get(string id);
+        Task<DuffelResponsePage<IEnumerable<Models.Aircraft>>> List(int limit = 50, string before = "", string after = "");
+        Task<IEnumerable<Models.Aircraft>> GetAll();
+    }
+
+    public class Aircraft : Resource<Models.Aircraft>, IAircraft
     {
         public Aircraft(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/Airlines.cs
+++ b/Duffel.ApiClient/Resources/Airlines.cs
@@ -1,9 +1,18 @@
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Duffel.ApiClient.Models;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Airlines : Resource<Airline>
+    public interface IAirlines
+    {
+        Task<Airline> Get(string id);
+        Task<DuffelResponsePage<IEnumerable<Airline>>> List(int limit = 50, string before = "", string after = "");
+        Task<IEnumerable<Airline>> GetAll();
+    }
+
+    public class Airlines : Resource<Airline>, IAirlines
     {
         public Airlines(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/Airports.cs
+++ b/Duffel.ApiClient/Resources/Airports.cs
@@ -1,9 +1,18 @@
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Duffel.ApiClient.Models;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Airports : Resource<Airport>
+    public interface IAirports
+    {
+        Task<Airport> Get(string id);
+        Task<DuffelResponsePage<IEnumerable<Airport>>> List(int limit = 50, string before = "", string after = "");
+        Task<IEnumerable<Airport>> GetAll();
+    }
+
+    public class Airports : Resource<Airport>, IAirports
     {
         public Airports(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/OfferRequests.cs
+++ b/Duffel.ApiClient/Resources/OfferRequests.cs
@@ -10,7 +10,28 @@ using OffersResponseConverter = Duffel.ApiClient.Converters.OffersResponseConver
 
 namespace Duffel.ApiClient.Resources
 {
-    public class OfferRequests : BaseResource<OffersResponse>
+    public interface IOfferRequests
+    {
+        /// <summary>
+        /// To search for flights, you'll need to create an offer request.
+        /// An offer request describes the passengers and where and when they want to travel (in the form of a list of slices).
+        /// It may also include additional filters (e.g. a particular cabin to travel in). 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="returnOffers">
+        /// When set to true, the offer request resource returned will include all the offers returned by the airlines.
+        /// If set to false, the offer request resource won't include any offers.
+        /// To retrieve the associated offers later, use the List Offers endpoint, specifying the offer_request_id.
+        /// You should use this option if you want to take advantage of the pagination, sorting and filtering that the List Offers endpoint provides.
+        /// </param>
+        Task<OffersResponse> Create(OffersRequest request, bool returnOffers = true);
+
+        Task<OffersResponse> Get(string offerRequestId);
+        Task<DuffelResponsePage<IEnumerable<OffersResponse>>> List(string before = "", string after = "", int limit = 50);
+        Task<IEnumerable<OffersResponse>> GetAll();
+    }
+
+    public class OfferRequests : BaseResource<OffersResponse>, IOfferRequests
     {
         public OfferRequests(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/Offers.cs
+++ b/Duffel.ApiClient/Resources/Offers.cs
@@ -11,7 +11,18 @@ using Newtonsoft.Json.Converters;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Offers : BaseResource<Offer>
+    public interface IOffers
+    {
+        Task<Offer> Get(string offerId, bool returnAvailableServices = false);
+
+        Task<DuffelResponsePage<IEnumerable<Offer>>> List(string offerRequestId, string before = "",
+            string after = "", int limit = 50, int maxConnections = 2,
+            string sortOrder = "total_amount");
+
+        Task<Passenger> UpdatePassenger(string offerId, Passenger passengerData);
+    }
+
+    public class Offers : BaseResource<Offer>, IOffers
     {
         public Offers(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/OrderCancellations.cs
+++ b/Duffel.ApiClient/Resources/OrderCancellations.cs
@@ -8,7 +8,29 @@ using Duffel.ApiClient.Models.Responses;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class OrderCancellations : BaseResource<OrderCancellation>
+    public interface IOrderCancellations
+    {
+        /// <summary>
+        /// To cancel an order, you'll need to create an order cancellation, check the refund_amount returned, and, if you're happy to go ahead and cancel the order.
+        /// The refund specified by refund_amount, if any, will be returned to your original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
+        /// </summary>
+        Task<OrderCancellation> Create(string orderId);
+
+        /// <summary>
+        /// Once you've created a pending order cancellation, you'll know the refund_amount you're due to get back.
+        /// To actually cancel the order, you'll need to confirm the cancellation. The booking with the airline will be cancelled, and the refund_amount will be returned to the original payment method (i.e. your Duffel balance). You'll then need to refund your customer (e.g. back to their credit/debit card).
+        /// </summary>
+        Task<OrderCancellation> Confirm(string cancellationRequestId);
+
+        /// <summary>
+        /// Retrieves an order cancellation by its ID.
+        /// </summary>
+        Task<OrderCancellation> Get(string cancellationRequestId);
+
+        Task<DuffelResponsePage<IEnumerable<OrderCancellation>>> List(string before = "", string after = "", int limit = 50, string order_id = "");
+    }
+
+    public class OrderCancellations : BaseResource<OrderCancellation>, IOrderCancellations
     {
         public OrderCancellations(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/OrderChangeOffers.cs
+++ b/Duffel.ApiClient/Resources/OrderChangeOffers.cs
@@ -6,7 +6,20 @@ using Duffel.ApiClient.Models.Responses.OrderChanges;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class OrderChangeOffers
+    public interface IOrderChangeOffers
+    {
+        /// <summary>
+        /// Retrieves an order change offer by its ID
+        /// </summary>
+        /// <param name="orderChangeOfferId">Duffel's unique identifier for the order change offer</param>
+        Task<OrderChangeOffer> Get(string orderChangeOfferId);
+
+        Task<DuffelResponsePage<IEnumerable<OrderChangeOffer>>> List(string orderChangeRequestId, string before = "",
+            string after = "", int limit = 50, int maxConnections = 2,
+            string sortOrder = "total_amount");
+    }
+
+    public class OrderChangeOffers : IOrderChangeOffers
     {
         private readonly HttpClient _httpClient;
 

--- a/Duffel.ApiClient/Resources/OrderChangeRequests.cs
+++ b/Duffel.ApiClient/Resources/OrderChangeRequests.cs
@@ -7,7 +7,13 @@ using Duffel.ApiClient.Models.Responses;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class OrderChangeRequests
+    public interface IOrderChangeRequests
+    {
+        Task<OrderChangeResponse> Create(OrderChangeRequest request);
+        Task<OrderChangeResponse> Get(string orderChangeRequestId);
+    }
+
+    public class OrderChangeRequests : IOrderChangeRequests
     {
         private readonly HttpClient _httpClient;
 

--- a/Duffel.ApiClient/Resources/OrderChanges.cs
+++ b/Duffel.ApiClient/Resources/OrderChanges.cs
@@ -11,7 +11,14 @@ using Newtonsoft.Json.Serialization;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class OrderChanges
+    public interface IOrderChanges
+    {
+        Task<OrderChange> Create(string orderChangeOfferId);
+        Task<OrderChange> Get(string orderChangeId);
+        Task<OrderChange> Confirm(string orderChangeId, Payment payment);
+    }
+
+    public class OrderChanges : IOrderChanges
     {
         private readonly HttpClient _httpClient;
 

--- a/Duffel.ApiClient/Resources/Orders.cs
+++ b/Duffel.ApiClient/Resources/Orders.cs
@@ -11,7 +11,21 @@ using PagedResponseConverter = Duffel.ApiClient.Converters.PagedResponseConverte
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Orders : BaseResource<Order>
+    public interface IOrders
+    {
+        /// <summary>
+        /// Creates a booking with an airline based on an offer.
+        /// Orders are usually paid at the time of creation, but can be held and paid for at a later date if the offer supports it (see offer.payment_requirements.requires_instant_payment). To create an order and pay for it at the same time, specify a payments key. To hold the order and pay for it later, specify the type as hold, omit the payments and services keys, and complete payment after creating the order through the Create a payment endpoint.
+        /// When presenting an order confirmation to your customers (e.g. on screen or in an email), you should include the booking_reference and details of the full itinerary and show the full name of the operating carrier of each segment (slices[].segments[].operating_carrier.name) in order to comply with US regulations.
+        /// If you receive a 500 Internal Server Error when trying to create an order, it may have still been created on the airline’s side. Please contact Duffel support before trying the request again. 
+        /// </summary>
+        Task<Order> Create(OrderRequest request);
+
+        Task<Order> Get(string orderId);
+        Task<Order> Update(string orderId, OrderMetadata metadata);
+    }
+
+    public class Orders : BaseResource<Order>, IOrders
     {
         public Orders(HttpClient httpClient) : base(httpClient)
         {

--- a/Duffel.ApiClient/Resources/Payments.cs
+++ b/Duffel.ApiClient/Resources/Payments.cs
@@ -7,7 +7,12 @@ using Duffel.ApiClient.Models.Responses;
 
 namespace Duffel.ApiClient.Resources
 {
-    public class Payments
+    public interface IPayments
+    {
+        Task<PaymentResponse> Create(PaymentRequest paymentRequest);
+    }
+
+    public class Payments : IPayments
     {
         private readonly HttpClient _httpClient;
 

--- a/Duffel.ApiClient/Resources/SeatMaps.cs
+++ b/Duffel.ApiClient/Resources/SeatMaps.cs
@@ -8,13 +8,18 @@ using Duffel.ApiClient.Models;
 
 namespace Duffel.ApiClient.Resources
 {
+    public interface ISeatMaps
+    {
+        Task<IEnumerable<SeatMap>> Get(string offerId);
+    }
+
     /// <summary>
     /// Seat maps are used to build a rich experience for your customers so they can select a seat as part of an order.
     /// A seat map includes the data for rendering seats in the relevant cabins, along with their total cost and other information such as disclosures.
     /// A seat is a special kind of service in that they're not shown when getting an individual offer with return_available_services set to true. They're only available through this endpoint.
     /// So far we support selecting seats when you create an order. This means we do not support selecting a seat after an order has already been created or cancelling a booked seat.
     /// </summary>
-    public class SeatMaps
+    public class SeatMaps : ISeatMaps
     {
         private readonly HttpClient _httpClient;
 


### PR DESCRIPTION
Gives flexibility to users to mock the client out without having to
implement an abstraction on top.

I checked README and examples, they didn't updating.