### PR TITLE
GH Action to publish nuget package

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore packages, build and test
-      run: dotnet test --verbosity normal
+      run: dotnet test
 
   publish:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build package
-      run: dotnet pack --verbosity normal -c Release -o ./output
+      run: dotnet pack -c Release -o ./output
     - name: Publish
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,4 +18,20 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Restore packages, build and test
-      run: dotnet test --verbosity normal -c Release -o ./output
+      run: dotnet test --verbosity normal
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Build package
+      run: dotnet pack --verbosity normal -c Release -o ./output
+    - name: Publish
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k${{secrets.NUGET_API_KEY}}
+

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,9 +17,5 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+    - name: Restore packages, build and test
+      run: dotnet test --verbosity normal -c Release -o ./output

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 .ionide/
 
 .idea/
+
+# output directory used in Github Actions CI builds
+output/

--- a/Duffel.ApiClient/Duffel.ApiClient.csproj
+++ b/Duffel.ApiClient/Duffel.ApiClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Authors>Duffel</Authors>
         <Copyright>Copyright 2022 Duffel Technology Ltd.</Copyright>
         <Company>Duffel Technology Ltd.</Company>

--- a/Duffel.ApiClient/Duffel.ApiClient.csproj
+++ b/Duffel.ApiClient/Duffel.ApiClient.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/examples/BookAndChange/BookAndChange.csproj
+++ b/examples/BookAndChange/BookAndChange.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/BookWithExtraBaggage/BookWithExtraBaggage.csproj
+++ b/examples/BookWithExtraBaggage/BookWithExtraBaggage.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/BookWithSeats/BookWithSeats.csproj
+++ b/examples/BookWithSeats/BookWithSeats.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/ExploringData/ExploringData.csproj
+++ b/examples/ExploringData/ExploringData.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/HoldAndPayLater/HoldAndPayLater.csproj
+++ b/examples/HoldAndPayLater/HoldAndPayLater.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/SearchAndBook/SearchAndBook.csproj
+++ b/examples/SearchAndBook/SearchAndBook.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Added github action to publish nuget package to nuget.org when a tag is pushed starting with v, e.g. v1.0.0-alpha

Also simplified the build and test as the seperate steps are not necessary, running dotnet test will build and restore packages.