### PR TITLE
Validate access token is provided

### DIFF
--- a/Duffel.ApiClient.Tests/ApiClientTests.cs
+++ b/Duffel.ApiClient.Tests/ApiClientTests.cs
@@ -1,0 +1,31 @@
+using NFluent;
+using NUnit.Framework;
+
+namespace Duffel.ApiClient.Tests
+{
+    using System;
+
+    public class DuffelApiClientTests
+    {
+        [Test]
+        public void ThrowsArgumentExceptionIfAccessTokenIsEmpty()
+        {
+            var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(String.Empty));
+            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.staging.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
+        }
+
+        [Test]
+        public void ThrowsArgumentExceptionIfAccessTokenIsNull()
+        {
+            var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(null));
+            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.staging.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
+        }
+
+        [Test]
+        public void ThrowsArgumentExceptionWithProductionUrlIfEnvIsProduction()
+        {
+            var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(String.Empty, true));
+            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
+        }
+    }
+}

--- a/Duffel.ApiClient/DuffelApiClient.cs
+++ b/Duffel.ApiClient/DuffelApiClient.cs
@@ -8,7 +8,7 @@ namespace Duffel.ApiClient
     public class DuffelApiClient : IDuffelApiClient
     {
         private readonly HttpClient _httpClient;
-        
+
         public IAirlines Airlines { get; set; }
         public IAirports Airports { get; set; }
         public IAircraft Aircraft { get; set; }
@@ -21,14 +21,21 @@ namespace Duffel.ApiClient
         public IOrderChanges OrderChanges { get; set; }
         public IOrderChangeOffers OrderChangeOffers { get; set; }
         public IOrderCancellations OrderCancellations { get; set; }
-        
+
         public DuffelApiClient(string accessToken, bool production = false)
         :this(new HttpClient(), accessToken, production)
         {
         }
-        
+
         public DuffelApiClient(HttpClient httpClient, string accessToken, bool production = false)
         {
+            if (string.IsNullOrWhiteSpace(accessToken))
+            {
+                var dashboardBaseAddress = production ? new Uri("https://app.duffel.com") : new Uri("https://app.staging.duffel.com");
+                var tokensAddress = new Uri(dashboardBaseAddress, "/duffel/tokens");
+                throw new ArgumentException( $@"No access token provided. To create an access token, head to your dashboard at {tokensAddress} and generate a token.", nameof(accessToken));
+            }
+
             _httpClient = httpClient;
             var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
             _httpClient.BaseAddress =

--- a/Duffel.ApiClient/DuffelApiClient.cs
+++ b/Duffel.ApiClient/DuffelApiClient.cs
@@ -23,19 +23,13 @@ namespace Duffel.ApiClient
         public IOrderCancellations OrderCancellations { get; set; }
         
         public DuffelApiClient(string accessToken, bool production = false)
+        :this(new HttpClient(), accessToken, production)
         {
-            _httpClient = new HttpClient();
-            Initialize(accessToken, production);
         }
         
         public DuffelApiClient(HttpClient httpClient, string accessToken, bool production = false)
         {
             _httpClient = httpClient;
-            Initialize(accessToken, production);
-        }
-
-        private void Initialize(string accessToken, bool production)
-        {
             var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
             _httpClient.BaseAddress =
                 production ? new Uri("https://api.duffel.com") : new Uri("https://api.staging.duffel.com");


### PR DESCRIPTION
- Use constructor overload instead of Initialise
- Return a meaningful error if no AccessToken provided
