### PR TITLE
Fix publish tag conditionals

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Build package
       run: dotnet pack -c Release -o ./output
     - name: Publish
-      run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k${{secrets.NUGET_API_KEY}}
+      run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k ${{secrets.NUGET_API_KEY}}
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,11 @@ name: .NET
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - "*"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-RC[0-9]+"
   pull_request:
     branches: [ main ]
 
@@ -21,6 +25,7 @@ jobs:
       run: dotnet test
 
   publish:
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'duffelhq/duffel-api-dotnet'
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -32,6 +37,5 @@ jobs:
     - name: Build package
       run: dotnet pack -c Release -o ./output
     - name: Publish
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k${{secrets.NUGET_API_KEY}}
 


### PR DESCRIPTION
What I had there didn't work when I tried as the publish didn't run. The
ref retruned was for main only.

Changing this to match what the [duffel-api-python](https://github.com/duffelhq/duffel-api-python/blob/main/.github/workflows/main.yaml#L17) library has.
