### PR TITLE
Set the nuget source to publish to

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Build package
       run: dotnet pack -c Release -o ./output
     - name: Publish
-      run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k ${{secrets.NUGET_API_KEY}}
+      run: dotnet nuget push ./output/Duffel.ApiClient.*.nupkg -k ${{secrets.NUGET_API_KEY}} -s 'https://api.nuget.org/v3/index.json'
 


### PR DESCRIPTION
Publish failed because no source was specfied and the environment
doesn't have a default source set. Passing it as an environment variable.

@sgerrand seeing the error message that the key was not specified was not enough after all 🤦 