### PR TITLE
Remove flights-api as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # See https://help.github.com/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 # for more information about the format and syntax of this file
 
-* @duffelhq/dotnet-maintainers @duffelhq/flights-api
+* @duffelhq/dotnet-maintainers


### PR DESCRIPTION
Flights API is no longer a team and hence no longer codeowners of this repository.