### PR TITLE
Remove production flag and correctly rely on token to determine test_mode

### DIFF
--- a/Duffel.ApiClient.Tests/ApiClientTests.cs
+++ b/Duffel.ApiClient.Tests/ApiClientTests.cs
@@ -11,20 +11,13 @@ namespace Duffel.ApiClient.Tests
         public void ThrowsArgumentExceptionIfAccessTokenIsEmpty()
         {
             var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(String.Empty));
-            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.staging.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
+            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
         }
 
         [Test]
         public void ThrowsArgumentExceptionIfAccessTokenIsNull()
         {
             var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(null));
-            Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.staging.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
-        }
-
-        [Test]
-        public void ThrowsArgumentExceptionWithProductionUrlIfEnvIsProduction()
-        {
-            var exception = Assert.Catch<ArgumentException>(() => new DuffelApiClient(String.Empty, true));
             Assert.AreEqual("No access token provided. To create an access token, head to your dashboard at https://app.duffel.com/duffel/tokens and generate a token. (Parameter 'accessToken')", exception?.Message);
         }
     }

--- a/Duffel.ApiClient/Duffel.ApiClient.csproj
+++ b/Duffel.ApiClient/Duffel.ApiClient.csproj
@@ -6,7 +6,7 @@
         <Copyright>Copyright 2022 Duffel Technology Ltd.</Copyright>
         <Company>Duffel Technology Ltd.</Company>
         <VersionPrefix>1.0.0</VersionPrefix>
-        <VersionSuffix>RC1</VersionSuffix>
+        <VersionSuffix>RC2</VersionSuffix>
         <Title>Duffel.ApiClient</Title>
         <Description>.NET client for interacting with the Duffel API https://docs.duffel.com/</Description>
         <PackageId>Duffel.ApiClient</PackageId>

--- a/Duffel.ApiClient/DuffelApiClient.cs
+++ b/Duffel.ApiClient/DuffelApiClient.cs
@@ -23,24 +23,23 @@ namespace Duffel.ApiClient
         public IOrderChangeOffers OrderChangeOffers { get; set; }
         public IOrderCancellations OrderCancellations { get; set; }
 
-        public DuffelApiClient(string accessToken, bool production = false)
-        :this(new HttpClient(new HttpClientHandler {AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate}), accessToken, production)
+        public DuffelApiClient(string accessToken)
+        :this(new HttpClient(new HttpClientHandler {AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate}), accessToken)
         {
         }
 
-        public DuffelApiClient(HttpClient httpClient, string accessToken, bool production = false)
+        public DuffelApiClient(HttpClient httpClient, string accessToken)
         {
             if (string.IsNullOrWhiteSpace(accessToken))
             {
-                var dashboardBaseAddress = production ? new Uri("https://app.duffel.com") : new Uri("https://app.staging.duffel.com");
+                var dashboardBaseAddress = new Uri("https://app.duffel.com");
                 var tokensAddress = new Uri(dashboardBaseAddress, "/duffel/tokens");
                 throw new ArgumentException( $@"No access token provided. To create an access token, head to your dashboard at {tokensAddress} and generate a token.", nameof(accessToken));
             }
 
             _httpClient = httpClient;
             var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
-            _httpClient.BaseAddress =
-                production ? new Uri("https://api.duffel.com") : new Uri("https://api.staging.duffel.com");
+            _httpClient.BaseAddress = new Uri("https://api.duffel.com");
 
             _httpClient.DefaultRequestHeaders.Add("User-Agent",
                 $"Duffel/beta {executingAssemblyName.Name}/{executingAssemblyName.Version}");

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Developers > Access Tokens.
 using Duffel.ApiClient;
 
 var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-var client = new DuffelApiClient(accessToken: accessToken, production: false);
+var client = new DuffelApiClient(accessToken: accessToken);
 ```
 
 After you have a client you can interact with, you can make calls to the Duffel API:

--- a/examples/BookAndChange/Program.cs
+++ b/examples/BookAndChange/Program.cs
@@ -10,7 +10,7 @@ using Duffel.ApiClient.Models.Requests;
 using Newtonsoft.Json;
 
 var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-var client = new DuffelApiClient(accessToken: accessToken, production: false);
+var client = new DuffelApiClient(accessToken: accessToken);
 
 try
 {

--- a/examples/BookWithExtraBaggage/Program.cs
+++ b/examples/BookWithExtraBaggage/Program.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 try
 {
     var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-    var client = new DuffelApiClient(accessToken: accessToken, production: false);
+    var client = new DuffelApiClient(accessToken: accessToken);
 
     var offersRequest = new OffersRequest
     {

--- a/examples/BookWithSeats/Program.cs
+++ b/examples/BookWithSeats/Program.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 try
 {
     var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-    var client = new DuffelApiClient(accessToken: accessToken, production: false);
+    var client = new DuffelApiClient(accessToken: accessToken);
 
     var offersRequest = new OffersRequest
     {

--- a/examples/ExploringData/Program.cs
+++ b/examples/ExploringData/Program.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 try
 {
     var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-    var client = new DuffelApiClient(accessToken: accessToken, production: false);
+    var client = new DuffelApiClient(accessToken: accessToken);
 
     Console.WriteLine("Loading airports...");
     var airports = await client.Airports.GetAll();

--- a/examples/HoldAndPayLater/Program.cs
+++ b/examples/HoldAndPayLater/Program.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 try
 {
     var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-    var client = new DuffelApiClient(accessToken: accessToken, production: false);
+    var client = new DuffelApiClient(accessToken: accessToken);
 
     var offersRequest = new OffersRequest
     {

--- a/examples/SearchAndBook/Program.cs
+++ b/examples/SearchAndBook/Program.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 try
 {
     var accessToken = Environment.GetEnvironmentVariable("DUFFEL_ACCESS_TOKEN");
-    var client = new DuffelApiClient(accessToken: accessToken, production: false);
+    var client = new DuffelApiClient(accessToken: accessToken);
 
     var offersRequest = new OffersRequest
     {


### PR DESCRIPTION
We were incorrectly switching between our internal staging environment and our regular production environment, instead of relying on just the token itself to determine if the request is 'test mode' or not.

All base urls stay the same across test_mode and real production requests, so the constructor `production` boolean is no longer needed.

Should solve #67 