### PR TITLE
Add CFAR support

### DIFF
--- a/Duffel.ApiClient/Models/Responses/Service.cs
+++ b/Duffel.ApiClient/Models/Responses/Service.cs
@@ -22,7 +22,7 @@ namespace Duffel.ApiClient.Models.Responses
         /// An object containing metadata about the service, like the maximum weight and dimensions of the baggage.
         /// </summary>
         [JsonProperty("metadata")]
-        public BaggageMetadata Metadata { get; set; }
+        public ServiceMetadata Metadata { get; set; }
         
         /// <summary>
         /// The list of passenger ids the service applies to. If you add this service to an order it will apply to all the passengers in this list. For services where the type is baggage, this list will include only a single passenger.
@@ -55,8 +55,10 @@ namespace Duffel.ApiClient.Models.Responses
         public string ServiceType { get; set; }
     }
     
-    public class BaggageMetadata
+    public class ServiceMetadata
     {
+        #region Baggage
+
         /// <summary>
         /// The maximum depth that the baggage can have in centimetres
         /// </summary>
@@ -87,6 +89,10 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("type")]
         public string BaggageType { get; set; }
+
+        #endregion
+
+        #region CFAR
         
         /// <summary>
         /// The amount the customer will receive back if the service is used, in total_currency
@@ -105,5 +111,7 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("terms_and_conditions_link")]
         public string TermsAndConditionsLink { get; set; }
+
+        #endregion
     }
 }

--- a/Duffel.ApiClient/Models/Responses/Service.cs
+++ b/Duffel.ApiClient/Models/Responses/Service.cs
@@ -87,5 +87,23 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("type")]
         public string BaggageType { get; set; }
+        
+        /// <summary>
+        /// The amount the customer will receive back if the service is used, in total_currency
+        /// </summary>
+        [JsonProperty("refund_amount")]
+        public string RefundAmount { get; set; }
+
+        /// <summary>
+        /// Information to display to customers
+        /// </summary>
+        [JsonProperty("merchant_copy")]
+        public string MerchantCopy { get; set; }
+
+        /// <summary>
+        /// URL with the terms and conditions for customers.
+        /// </summary>
+        [JsonProperty("terms_and_conditions_link")]
+        public string TermsAndConditionsLink { get; set; }
     }
 }


### PR DESCRIPTION
This is a quick-and-dirty addition of cancel for any reason support.
I guess using a proper JSON converter is better, but that may introduce exceptions when the service types expand later on.

An alternative would be to:

* Change `Service` to return `IServiceMetadata`:
* 
```diff
        /// <summary>
        /// An object containing metadata about the service, like the maximum weight and dimensions of the baggage.
        /// </summary>
        [JsonProperty("metadata")]
+       [JsonConverter(typeof(ServiceMetadataJsonConverter))]
+       public IServiceMetadata Metadata { get; set; }
-       public BaggageMetadataMetadata { get; set; }
```

* Change `BaggageMetadata` to implement `IServiceMetadata`:

```diff
+public interface IServiceMetadata { }
+
+ public class BaggageMetadata : IServiceMetadata
- public class BaggageMetadata
```

* Add `CancelForAnyReasonMetadata`:

```diff
+ public class CancelForAnyReasonMetadata : IServiceMetadata
+ {
+     /// <summary>
+     /// The amount the customer will receive back if the service is used, in total_currency
+     /// </summary>
+     [JsonProperty("refund_amount")]
+     public string RefundAmount { get; set; }
+ 
+     /// <summary>
+     /// Information to display to customers
+     /// </summary>
+     [JsonProperty("merchant_copy")]
+     public string MerchantCopy { get; set; }
+ 
+     /// <summary>
+     /// URL with the terms and conditions for customers.
+     /// </summary>
+     [JsonProperty("terms_and_conditions_link")]
+     public string TermsAndConditionsLink { get; set; }
+ 
+     /// <summary>
+     /// The type of the service metadata.
+     /// Possible value: "cancel_for_any_reason"
+     /// </summary>
+     [JsonProperty("type")]
+     public string Type { get; set; }
+ }
```

* Add `ServiceMetadataJsonConverter`:

```diff
+ public class ServiceMetadataJsonConverter : JsonConverter
+ {
+     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+     {
+         throw new NotImplementedException();
+     }
+ 
+     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+     {
+         JObject jo = JObject.Load(reader);
+         var metadataType = (string)jo["type"]!;
+ 
+         switch (metadataType.ToLower())
+         {
+             case "carry_on":
+             case "checked":
+                 var bagsMd = new BaggageMetadata();
+                 serializer.Populate(jo.CreateReader(), bagsMd);
+                 return bagsMd;
+ 
+             case "cancel_for_any_reason":
+                 var cfarMd = new CancelForAnyReasonMetadata();
+                 serializer.Populate(jo.CreateReader(), cfarMd);
+                 return cfarMd;
+ 
+             default:
+                 throw new NotImplementedException($"Service metadata type: {metadataType} is not supported!");
+         }
+     }
+ 
+     public override bool CanConvert(Type objectType)
+     {
+         return true;
+     }
+ }
```

Given the risk of breaking forward-compatibility with the introduction of this `ServiceMetadataJsonConverter`, it looks like you may want to discuss this within the Duffel dev team first 😃 