### PR TITLE
Add KTN and PRN as supported document types

### DIFF
--- a/Duffel.ApiClient.Tests/Fixtures/offer_response_ow_3pass_ber_lhr.json
+++ b/Duffel.ApiClient.Tests/Fixtures/offer_response_ow_3pass_ber_lhr.json
@@ -350,6 +350,12 @@
     "base_currency": "GBP",
     "base_amount": "4272.00",
     "available_services": [],
+    "supported_passenger_identity_document_types": [
+      "passport",
+      "tax_id",
+      "known_traveler_number",
+      "passenger_redress_number"
+    ],
     "allowed_passenger_identity_document_types": [
       "passport"
     ]

--- a/Duffel.ApiClient.Tests/Fixtures/offers_response_full_ow_sfo_jfk.json
+++ b/Duffel.ApiClient.Tests/Fixtures/offers_response_full_ow_sfo_jfk.json
@@ -313,6 +313,7 @@
         },
         "base_currency": "GBP",
         "base_amount": "431.66",
+        "supported_passenger_identity_document_types": [],
         "allowed_passenger_identity_document_types": []
       },
       {
@@ -567,6 +568,7 @@
         },
         "base_currency": "GBP",
         "base_amount": "431.66",
+        "supported_passenger_identity_document_types": [],
         "allowed_passenger_identity_document_types": []
       },
       {
@@ -797,6 +799,7 @@
         },
         "base_currency": "GBP",
         "base_amount": "397.29",
+        "supported_passenger_identity_document_types": [],
         "allowed_passenger_identity_document_types": []
       },
       {
@@ -1051,6 +1054,7 @@
         },
         "base_currency": "GBP",
         "base_amount": "369.11",
+        "supported_passenger_identity_document_types": [],
         "allowed_passenger_identity_document_types": []
       }],
     "live_mode": false,

--- a/Duffel.ApiClient/Converters/Json/IdentityDocumentJsonConverter.cs
+++ b/Duffel.ApiClient/Converters/Json/IdentityDocumentJsonConverter.cs
@@ -15,11 +15,19 @@ namespace Duffel.ApiClient.Converters.Json
             {
                 var items = identityDocuments.Select(document =>
                 {
-                    if (document is Passport passport)
+                    switch (document)
                     {
-                        return $"{{\"type\":\"passport\",\"expires_on\":\"{passport.ExpiresOn}\",\"issuing_country_code\":\"{passport.IssuingCountryCode}\",\"unique_identifier\":\"{passport.UniqueIdentifier}\"}}";
+                        case Passport passport:
+                            return $"{{\"type\":\"passport\",\"expires_on\":\"{passport.ExpiresOn}\",\"issuing_country_code\":\"{passport.IssuingCountryCode}\",\"unique_identifier\":\"{passport.UniqueIdentifier}\"}}";
+                        case KnownTravelerNumber knownTravelerNumber:
+                            return $"{{\"type\":\"known_traveler_number\",\"issuing_country_code\":\"{knownTravelerNumber.IssuingCountryCode}\",\"unique_identifier\":\"{knownTravelerNumber.UniqueIdentifier}\"}}";
+                        case PassengerRedressNumber passengerRedressNumber:
+                            return $"{{\"type\":\"passenger_redress_number\",\"issuing_country_code\":\"{passengerRedressNumber.IssuingCountryCode}\",\"unique_identifier\":\"{passengerRedressNumber.UniqueIdentifier}\"}}";
+                        case TaxId taxId:
+                            return $"{{\"type\":\"tax_id\",\"unique_identifier\":\"{taxId.UniqueIdentifier}\"}}";
+                        default:
+                            throw new NotImplementedException($"Identity document of type: {document.GetType().ToString()} is not supported,");
                     }
-                    throw new NotImplementedException($"Identity document of type: {document.GetType().ToString()} is not supported,");
                 });
                 var payload = $"{string.Join(",", items)}";
                 writer.WriteStartArray();
@@ -37,18 +45,25 @@ namespace Duffel.ApiClient.Converters.Json
             JObject jo = JObject.Load(reader);
             var documentType = (string)jo["type"]!;
             IdentityDocument result;
-            
+
             switch(documentType?.ToLower())
             {
                 case "passport":
                     result = new Passport();
                     break;
-                
-                
+                case "known_traveler_number":
+                    result = new KnownTravelerNumber();
+                    break;
+                case "passenger_redress_number":
+                    result = new PassengerRedressNumber();
+                    break;
+                case "tax_id":
+                    result = new TaxId();
+                    break;
                 default:
                     throw new NotImplementedException($"{documentType} is not a recognised identity document type.");
             };
-            
+
             serializer.Populate(jo.CreateReader(), result);
             return result;
         }

--- a/Duffel.ApiClient/Models/IdentityDocuments/KnownTravelerNumber.cs
+++ b/Duffel.ApiClient/Models/IdentityDocuments/KnownTravelerNumber.cs
@@ -1,0 +1,20 @@
+﻿namespace Duffel.ApiClient.Models.IdentityDocuments
+{
+    using Newtonsoft.Json;
+
+    public class KnownTravelerNumber : IdentityDocument
+    {
+        /// <summary>
+        /// The ISO 3166-1 alpha-2 code of the country that issued this identity document
+        /// </summary>
+        [JsonProperty("issuing_country_code")]
+        public string IssuingCountryCode { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the identity document. e.g. the known traveler number.
+        /// </summary>
+        [JsonProperty("unique_identifier")]
+        public string UniqueIdentifier { get; set; }
+
+    }
+}

--- a/Duffel.ApiClient/Models/IdentityDocuments/PassengerRedressNumber.cs
+++ b/Duffel.ApiClient/Models/IdentityDocuments/PassengerRedressNumber.cs
@@ -1,0 +1,20 @@
+﻿namespace Duffel.ApiClient.Models.IdentityDocuments
+{
+    using Newtonsoft.Json;
+
+    public class PassengerRedressNumber : IdentityDocument
+    {
+        /// <summary>
+        /// The ISO 3166-1 alpha-2 code of the country that issued this identity document
+        /// </summary>
+        [JsonProperty("issuing_country_code")]
+        public string IssuingCountryCode { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the identity document. e.g. the passenger redress number.
+        /// </summary>
+        [JsonProperty("unique_identifier")]
+        public string UniqueIdentifier { get; set; }
+
+    }
+}

--- a/Duffel.ApiClient/Models/IdentityDocuments/Passport.cs
+++ b/Duffel.ApiClient/Models/IdentityDocuments/Passport.cs
@@ -9,18 +9,18 @@ namespace Duffel.ApiClient.Models.IdentityDocuments
         /// </summary>
         [JsonProperty("expires_on")]
         public string ExpiresOn { get; set; }
-        
+
         /// <summary>
         /// The ISO 3166-1 alpha-2 code of the country that issued this identity document
         /// </summary>
         [JsonProperty("issuing_country_code")]
         public string IssuingCountryCode { get; set; }
-        
+
         /// <summary>
-        /// The type of the identity document. Currently, the only supported type is passport. This must be one of the allowed_passenger_identity_document_types on the offer.
+        /// The unique identifier of the identity document. e.g. the passport number.
         /// </summary>
         [JsonProperty("unique_identifier")]
-        public string UniqueIdentifier { get; set; } 
-        
+        public string UniqueIdentifier { get; set; }
+
     }
 }

--- a/Duffel.ApiClient/Models/IdentityDocuments/TaxId.cs
+++ b/Duffel.ApiClient/Models/IdentityDocuments/TaxId.cs
@@ -1,0 +1,14 @@
+﻿namespace Duffel.ApiClient.Models.IdentityDocuments
+{
+    using Newtonsoft.Json;
+
+    public class TaxId : IdentityDocument
+    {
+        /// <summary>
+        /// The unique identifier of the identity document. e.g. the tax id.
+        /// </summary>
+        [JsonProperty("unique_identifier")]
+        public string UniqueIdentifier { get; set; }
+
+    }
+}

--- a/Duffel.ApiClient/Models/Requests/OrderPassenger.cs
+++ b/Duffel.ApiClient/Models/Requests/OrderPassenger.cs
@@ -12,62 +12,65 @@ namespace Duffel.ApiClient.Models.Requests
         /// </summary>
         [JsonProperty("type")]
         public PassengerType PassengerType { get; set; }
-        
+
         /// <summary>
         /// The passenger's title
         /// </summary>
         [JsonProperty("title")]
         public string Title { get; set; }
-        
+
         /// <summary>
         /// The passenger's phone number in E.164 (international) format
         /// </summary>
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
-        
+
         /// <summary>
         /// Infant passengers, with an age of 0 or 1, must be associated with an adult passenger. This field should be used to make this association. It should contain the id of the infant passenger as returned in the <see cref="OffersRequest"/>.
         /// </summary>
         [JsonProperty("infant_passenger_id")]
         public string InfantPassengerId { get; set; }
-        
+
         /// <summary>
-        /// The passenger's identity documents. You may only provide one identity document per passenger. The identity document's type must be included in the offer's allowed_passenger_identity_document_types. If the offer's passenger_identity_documents_required is set to true, then an identity document must be provided.
+        /// The passenger's identity documents.
+        /// You may only provide one identity document per type per passenger.
+        /// The identity document's type must be included in the offer's supported_passenger_identity_document_types.
+        /// If the offer's passenger_identity_documents_required is set to true, then an identity document must be provided.
         /// </summary>
         [JsonProperty("identity_documents")]
         [JsonConverter(typeof(IdentityDocumentJsonConverter))]
         public IEnumerable<IdentityDocument> IdentityDocuments { get; set; }
-        
+
         /// <summary>
         /// The id of the passenger, returned when the <see cref="OffersRequest"/> was created
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
-        
+
         /// <summary>
         /// The passenger's gender
         /// </summary>
         [JsonProperty("gender")]
         public Gender Gender { get; set; }
-        
+
         /// <summary>
         /// The passenger's given name. Only space, -, ', and letters from the ASCII, Latin-1 Supplement and Latin Extended-A (with the exceptions of Æ, æ, Ĳ, ĳ, Œ, œ, Þ, and ð) Unicode charts are accepted. All other characters will result in a validation error. The minimum length is 1 character, and the maximum is 20 characters.
         /// </summary>
         [JsonProperty("given_name")]
         public string GivenName { get; set; }
-        
+
         /// <summary>
         /// The passenger's family name. Only space, -, ', and letters from the ASCII, Latin-1 Supplement and Latin Extended-A (with the exceptions of Æ, æ, Ĳ, ĳ, Œ, œ, Þ, and ð) Unicode charts are accepted. All other characters will result in a validation error. The minimum length is 1 character, and the maximum is 20 characters.
         /// </summary>
         [JsonProperty("family_name")]
         public string FamilyName { get; set; }
-        
+
         /// <summary>
         /// The passenger's email address
         /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
-        
+
         /// <summary>
         /// The passenger's date of birth
         /// </summary>

--- a/Duffel.ApiClient/Models/Responses/Offer.cs
+++ b/Duffel.ApiClient/Models/Responses/Offer.cs
@@ -14,13 +14,13 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("updated_at")]
         public DateTime UpdatedAt { get; set; }
-        
+
         /// <summary>
         /// An estimate of the total carbon dioxide (CO₂) emissions when all of the passengers fly this offer's itinerary, measured in kilograms
         /// </summary>
         [JsonProperty("total_emissions_kg")]
         public string TotalEmissionsKg { get; set; }
-        
+
         /// <summary>
         /// The currency of the total_amount, as an ISO 4217 currency code.
         /// It will match your organisation's billing currency unless you’re using Duffel as an accredited IATA agent,
@@ -28,20 +28,20 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("total_currency")]
         public string TotalCurrency { get; set; }
-        
+
         /// <summary>
         /// The total price of the offer for all passengers, including taxes.
         /// It does not include the total price of any service(s) that might be booked with the offer.
         /// </summary>
         [JsonProperty("total_amount")]
         public string TotalAmount { get; set; }
-        
+
         [JsonProperty("tax_currency")]
         public string TaxCurrency { get; set; }
-        
+
         [JsonProperty("tax_amount")]
         public string TaxAmount { get; set; }
-        
+
         /// <summary>
         /// The slices that make up this offer.
         /// Each slice will include one or more segments, the specific flights that the airline is offering to take the passengers from the slice's origin to its destination.
@@ -55,7 +55,7 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("payment_requirements")]
         public PaymentRequirements PaymentRequirements { get; set; }
-        
+
         /// <summary>
         /// The services that can be booked along with the offer but are not included by default, for example an additional checked bag. This field is only returned in the Get single offer endpoint. When there are no services available, or we don't support services for the airline, this list will be empty. If you want to know which airlines we support services for, please get in touch with the Duffel support team at help@duffel.com.
         /// </summary>
@@ -74,40 +74,40 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("passenger_identity_documents_required")]
         public bool PassengerIdentityDocumentsRequired { get; set; }
-        
+
         /// <summary>
         /// The airline which provided the offer
         /// </summary>
         [JsonProperty("owner")]
         public Airline Owner { get; set; }
-        
+
         /// <summary>
         /// Whether the offer request was created in live mode.
         /// This field will be set to true if the offer request was created in live mode, or false if it was created in test mode.
         /// </summary>
         [JsonProperty("live_mode")]
         public bool LiveMode { get; set; }
-        
+
         /// <summary>
         /// Duffel's unique identifier for the offer
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
-        
+
         /// <summary>
         /// The ISO 8601 datetime at which the offer will expire and no longer be usable to create an order
         /// </summary>
         [JsonProperty("expires_at")]
         public DateTime ExpiresAt { get; set; }
-        
+
         /// <summary>
         /// The ISO 8601 datetime at which the offer was created
         /// </summary>
         [JsonProperty("created_at")]
         public DateTime CreatedAt { get; set; }
-        
+
         // conditions
-        
+
         /// <summary>
         /// The currency of the <see cref="BaseAmount"/>, as an ISO 4217 currency code.
         /// It will match your organisation's billing currency unless you’re using Duffel as an accredited IATA agent,
@@ -116,19 +116,31 @@ namespace Duffel.ApiClient.Models.Responses
         /// </summary>
         [JsonProperty("base_currency")]
         public string BaseCurrency { get; set; }
-        
+
         /// <summary>
         /// The base price of the offer for all passengers, excluding taxes.
         /// It does not include the base amount of any service(s) that might be booked with the offer.
         /// </summary>
         [JsonProperty("base_amount")]
         public string BaseAmount{ get; set; }
-        
+
+        /// <summary>
+        /// The types of identity documents supported by the airline and may be provided for the passengers when creating an order based on this offer.
+        /// Currently, possible types are passport, tax_id, known_traveler_number, and passenger_redress_number.
+        /// </summary>
+        [JsonProperty("supported_passenger_identity_document_types")]
+        public IEnumerable<string> SupportedPassengerIdentityDocumentTypes { get; set; }
+
         /// <summary>
         /// The types of identity documents that may be provided for the passengers when creating an order based on this offer.
-        /// Currently, the only supported type is passport.
+        /// Currently, possible types are passport, tax_id, known_traveler_number, and passenger_redress_number.
         /// If this is empty, then you must not provide identity documents.
         /// </summary>
+        /// <remarks>
+        /// This field has been deprecated and the supported_passenger_identity_document_types field provides equivalent behaviour.
+        /// See https://duffel.com/docs/api/v1/offers/schema#offers-schema-allowed-passenger-identity-document-types for more details.
+        /// </remarks>
+        [Obsolete("This field has been deprecated and the supported_passenger_identity_document_types field provides equivalent behaviour. See https://duffel.com/docs/api/v1/offers/schema#offers-schema-allowed-passenger-identity-document-types for more details.")]
         [JsonProperty("allowed_passenger_identity_document_types")]
         public IEnumerable<string> AllowedPassengerIdentityDocumentTypes { get; set; }
 


### PR DESCRIPTION
As per https://changelog.duffel.com/announcements/adding-ktn-and-prn-as-supported-document-types