### PR TITLE
Add airline loyalty programme logo and accepted_loyalty_programmes pport

### DIFF
--- a/Duffel.ApiClient/Models/LoyaltyProgramme.cs
+++ b/Duffel.ApiClient/Models/LoyaltyProgramme.cs
@@ -4,16 +4,34 @@ namespace Duffel.ApiClient.Models
 
     public class LoyaltyProgramme
     {
+        /// <summary>
+        /// Duffel's unique identifier for the loyalty programme.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// The name of the alliance this loyalty programme is part of.
+        /// </summary>
         [JsonProperty("alliance")]
         public string Alliance { get; set; }
 
+        /// <summary>
+        /// Name of the loyalty programme.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// The Duffel ID of the airline that corresponds to the loyalty programme.
+        /// </summary>
         [JsonProperty("owner_airline_id")]
         public string OwnerAirlineId { get; set; }
+
+        /// <summary>
+        /// Path to a svg of the loyalty programme logo. This may be null if no logo is available.
+        /// </summary>
+        [JsonProperty("logo_url")]
+        public string LogoUrl { get; set; }
     }
 }

--- a/Duffel.ApiClient/Models/Responses/Offer.cs
+++ b/Duffel.ApiClient/Models/Responses/Offer.cs
@@ -132,6 +132,16 @@ namespace Duffel.ApiClient.Models.Responses
         public IEnumerable<string> SupportedPassengerIdentityDocumentTypes { get; set; }
 
         /// <summary>
+        /// A list of airline IATA codes whose loyalty programmes will be accepted when booking the offer.
+        /// Loyalty programmes present within the offer passengers that are not present in this field shall be ignored at booking.
+        /// </summary>
+        /// <remarks>
+        /// If this is an empty list ([]), no loyalty programmes are accepted for the offer and shall be ignored if provided.
+        /// </remarks>
+        [JsonProperty("accepted_loyalty_programmes")]
+        public IEnumerable<string> AcceptedLoyaltyProgrammes { get; set; }
+
+        /// <summary>
         /// The types of identity documents that may be provided for the passengers when creating an order based on this offer.
         /// Currently, possible types are passport, tax_id, known_traveler_number, and passenger_redress_number.
         /// If this is empty, then you must not provide identity documents.


### PR DESCRIPTION
See https://changelog.duffel.com/announcements/you-can-now-see-the-loyalty-programmes-that-are-accepted-for-a-specific-offer